### PR TITLE
Refactor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@
  * propagation for state changes into the non-react map
  */
 import React from "react";
-import { onInitializeRegen, registerHandlers } from "./Map";
+import { registerHandlers } from "./Map";
 import Map from "./Map";
 import Select from "react-select";
 import { algoOptions, metroOptions } from "./Data";
@@ -55,6 +55,7 @@ class App extends React.Component {
       selectedMetroOption: getDefault(metroOptions, "metro"),
       selectedAlgoOption: getDefault(algoOptions, "algo"),
       showSpinner: true,
+      regenData: false,
       chartData: {
         latencyData: [],
         durationData: [],
@@ -99,12 +100,7 @@ class App extends React.Component {
     };
 
     this.regenerateData = () => {
-      this.setState({ showSpinner: true }, () => {
-        onInitializeRegen(
-          this.state.selectedMetroOption.value,
-          this.state.selectedAlgoOption.value
-        );
-      });
+      this.setState({ showSpinner: true, regenData: true });
     };
 
     // There must be a better way to handle cross
@@ -112,6 +108,7 @@ class App extends React.Component {
     registerHandlers((chartData) => {
       this.setState((prevState) => {
         prevState.showSpinner = false;
+        prevState.regenData = false;
         prevState.chartData.latencyData = chartData.latencyData;
         prevState.chartData.distanceData = chartData.distanceData;
         prevState.chartData.durationData = chartData.durationData;
@@ -177,6 +174,7 @@ class App extends React.Component {
           <Map
             metro={this.state.selectedMetroOption.value}
             algo={this.state.selectedAlgoOption.value}
+            regenData={this.state.regenData}
           />
         </div>
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -21,12 +21,8 @@
  * propagation for state changes into the non-react map
  */
 import React from "react";
-import {
-  onMetroChange,
-  onAlgoChange,
-  onInitializeRegen,
-  registerHandlers,
-} from "./Map";
+import { onInitializeRegen, registerHandlers } from "./Map";
+import Map from "./Map";
 import Select from "react-select";
 import { algoOptions, metroOptions } from "./Data";
 import { find, debounce, findIndex, filter } from "lodash";
@@ -65,8 +61,7 @@ class App extends React.Component {
         distanceData: [],
       },
     };
-    onMetroChange(this.state.selectedMetroOption.value);
-    onAlgoChange(this.state.selectedAlgoOption.value);
+
     if (!keyboardListener) {
       keyboardListener = document.addEventListener(
         "keydown",
@@ -93,14 +88,12 @@ class App extends React.Component {
 
     this.handleMetroChange = (selectedMetroOption) => {
       this.setState({ showSpinner: true, selectedMetroOption }, () => {
-        onMetroChange(this.state.selectedMetroOption.value);
         setQueryStringValue("metro", this.state.selectedMetroOption.value);
       });
     };
 
     this.handleAlgoChange = (selectedAlgoOption) => {
       this.setState({ showSpinner: true, selectedAlgoOption }, () => {
-        onAlgoChange(this.state.selectedAlgoOption.value);
         setQueryStringValue("algo", this.state.selectedAlgoOption.value);
       });
     };
@@ -148,13 +141,13 @@ class App extends React.Component {
 
   render() {
     return (
-      <span>
-        <Select
-          value={this.state.selectedAlgoOption}
-          onChange={this.handleAlgoChange}
-          options={filter(algoOptions, { enabled: true })}
-        />
-        <div>
+      <div>
+        <div style={{ width: "100%" }}>
+          <Select
+            value={this.state.selectedAlgoOption}
+            onChange={this.handleAlgoChange}
+            options={filter(algoOptions, { enabled: true })}
+          />
           <div style={{ width: "300px", float: "left" }}>
             <Select
               value={this.state.selectedMetroOption}
@@ -177,7 +170,13 @@ class App extends React.Component {
             <button onClick={this.downloadData}>Download</button>
           </div>
         </div>
-      </span>
+        <div style={{ marginLeft: "300px" }}>
+          <Map
+            metro={this.state.selectedMetroOption.value}
+            algo={this.state.selectedAlgoOption.value}
+          />
+        </div>
+      </div>
     );
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,6 @@
  * propagation for state changes into the non-react map
  */
 import React from "react";
-import { registerHandlers } from "./Map";
 import Map from "./Map";
 import Select from "react-select";
 import { algoOptions, metroOptions } from "./Data";
@@ -103,18 +102,21 @@ class App extends React.Component {
       this.setState({ showSpinner: true, regenData: true });
     };
 
-    // There must be a better way to handle cross
-    // component communication
-    registerHandlers((chartData) => {
+    this.onChartDataUpdate = (chartData) => {
       this.setState((prevState) => {
-        prevState.showSpinner = false;
-        prevState.regenData = false;
-        prevState.chartData.latencyData = chartData.latencyData;
-        prevState.chartData.distanceData = chartData.distanceData;
-        prevState.chartData.durationData = chartData.durationData;
-        return prevState;
+        return {
+          selectedMetroOption: prevState.selectedMetroOption,
+          selectedAlgoOption: prevState.selectedAlgoOption,
+          showSpinner: false,
+          regenData: false,
+          chartData: {
+            latencyData: chartData.latencyData,
+            distanceData: chartData.distanceData,
+            durationData: chartData.durationData,
+          },
+        };
       });
-    });
+    };
 
     this.downloadData = async () => {
       const metro = this.state.selectedMetroOption.value;
@@ -175,6 +177,7 @@ class App extends React.Component {
             metro={this.state.selectedMetroOption.value}
             algo={this.state.selectedAlgoOption.value}
             regenData={this.state.regenData}
+            onChartDataUpdate={this.onChartDataUpdate}
           />
         </div>
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -100,7 +100,10 @@ class App extends React.Component {
 
     this.regenerateData = () => {
       this.setState({ showSpinner: true }, () => {
-        onInitializeRegen();
+        onInitializeRegen(
+          this.state.selectedMetroOption.value,
+          this.state.selectedAlgoOption.value
+        );
       });
     };
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -52,10 +52,11 @@ function initializeMapObject(element) {
   });
 }
 
-function MyMapComponent() {
+function MyMapComponent({ metro, algo }) {
   const ref = useRef();
 
   useEffect(() => {
+    console.log("Gots apikey", apiKey);
     map = initializeMapObject(ref.current);
 
     // Polygons should really have a getBounds method (v2 maps did).
@@ -76,15 +77,27 @@ function MyMapComponent() {
         return bounds;
       };
     }
-    fitToMetroBounds(map, currentMetro);
+  }, []);
+
+  useEffect(() => {
+    console.log("on metro change", metro);
+    currentMetro = metro;
+    if (window.google && window.google.maps) {
+      fitToMetroBounds(map, metro);
+    }
     onStateChangeDebounced();
-  });
+  }, [metro]);
+
+  useEffect(() => {
+    console.log("on algo change", algo);
+    currentAlgo = algo;
+    onStateChangeDebounced();
+  }, [algo]);
 
   return <div ref={ref} id="map" style={{ height: "1024px" }} />;
 }
 
-function Map() {
-  console.log("Gots apikey", apiKey);
+function Map({ metro, algo }) {
   return (
     <Wrapper
       apiKey={apiKey}
@@ -92,24 +105,9 @@ function Map() {
       version="beta"
       libraries={["geometry", "journeySharing"]}
     >
-      <MyMapComponent />
+      <MyMapComponent metro={metro} algo={algo} />
     </Wrapper>
   );
-}
-
-function onMetroChange(metro) {
-  console.log("on metro change", metro);
-  currentMetro = metro;
-  if (window.google && window.google.maps) {
-    fitToMetroBounds(map, metro);
-  }
-  onStateChangeDebounced();
-}
-
-function onAlgoChange(algo) {
-  console.log("on algo change", algo);
-  currentAlgo = algo;
-  onStateChangeDebounced();
 }
 
 function onInitializeRegen() {
@@ -240,10 +238,4 @@ function registerHandlers(newChartDataHandler) {
   chartDataHandler = newChartDataHandler;
 }
 
-export {
-  Map as default,
-  onMetroChange,
-  onAlgoChange,
-  registerHandlers,
-  onInitializeRegen,
-};
+export { Map as default, registerHandlers, onInitializeRegen };

--- a/src/Map.js
+++ b/src/Map.js
@@ -31,7 +31,6 @@ const apiKey = process.env.REACT_APP_GOOGLE_MAPS_API_KEY;
 let googleMap;
 let shownPolys = [];
 let shownMarkers = [];
-let chartDataHandler;
 
 const render = (status) => {
   if (status === Status.LOADING) return <h3>{status} ..</h3>;
@@ -50,7 +49,7 @@ function initializeMapObject(element) {
   });
 }
 
-function MyMapComponent({ metro, algo, regenData }) {
+function MyMapComponent({ metro, algo, regenData, onChartDataUpdate }) {
   const ref = useRef();
 
   /*
@@ -143,7 +142,7 @@ function MyMapComponent({ metro, algo, regenData }) {
       return poly;
     });
 
-    chartDataHandler(await GetChartData(googleMap, metro, algo));
+    onChartDataUpdate(await GetChartData(googleMap, metro, algo));
   }, 100);
 
   useEffect(() => {
@@ -193,7 +192,7 @@ function MyMapComponent({ metro, algo, regenData }) {
   return <div ref={ref} id="map" style={{ height: "1024px" }} />;
 }
 
-function Map({ metro, algo, regenData }) {
+function Map(props) {
   return (
     <Wrapper
       apiKey={apiKey}
@@ -201,7 +200,12 @@ function Map({ metro, algo, regenData }) {
       version="beta"
       libraries={["geometry", "journeySharing"]}
     >
-      <MyMapComponent metro={metro} algo={algo} regenData={regenData} />
+      <MyMapComponent
+        metro={props.metro}
+        algo={props.algo}
+        regenData={props.regenData}
+        onChartDataUpdate={props.onChartDataUpdate}
+      />
     </Wrapper>
   );
 }
@@ -232,8 +236,4 @@ const endSymbol = {
 };
 */
 
-function registerHandlers(newChartDataHandler) {
-  chartDataHandler = newChartDataHandler;
-}
-
-export { Map as default, registerHandlers };
+export { Map as default };

--- a/src/index.js
+++ b/src/index.js
@@ -19,16 +19,5 @@
  */
 import ReactDOM from "react-dom";
 import App from "./App";
-import Map from "./Map";
 
-ReactDOM.render(
-  <div>
-    <div style={{ width: "100%" }}>
-      <App />
-    </div>
-    <div style={{ marginLeft: "300px" }}>
-      <Map />
-    </div>
-  </div>,
-  document.getElementById("root")
-);
+ReactDOM.render(<App />, document.getElementById("root"));


### PR DESCRIPTION
Moved Map to be a child component of App.
- Let App pass props to Map for rendering.
- Let Map call "onChange" functions that App provides to update App state.
This simplifies the interaction between the two components and makes the code look more like a standard React App
 
Map now has multiple UseEffect functions:
- One that only gets called once on component mount and initializes values
- One that gets called when "metro" gets updated (replacement of original onMetroChange)
- One that gets called when "algo" gets updated (replacement of original onAlgoChange)
- One that gets called when the Regenerate button gets clicked (replacement of original OnInitializeRegen)
Also moved OnStateChangedDebounced into the Map component so it could read the "metro" and "algo" props directly
Also renamed "map" to "googleMap" to clearly indicate it was the Google Map Object.
